### PR TITLE
feat: add customEvent & update qq music regex

### DIFF
--- a/source/Meting.js
+++ b/source/Meting.js
@@ -5,7 +5,11 @@ class MetingJSElement extends HTMLElement {
   connectedCallback() {
     if (window.APlayer && window.fetch) {
       this._init()
-      this._parse()
+      this._parse().catch(error => {
+        console.error(error)
+        const customEvent = new CustomEvent('parse-error', { detail: { error } })
+        this.dispatchEvent(customEvent)
+      })
     }
   }
 
@@ -50,11 +54,11 @@ class MetingJSElement extends HTMLElement {
       ['music.163.com.*artist.*id=(\\d+)', 'netease', 'artist'],
       ['music.163.com.*playlist.*id=(\\d+)', 'netease', 'playlist'],
       ['music.163.com.*discover/toplist.*id=(\\d+)', 'netease', 'playlist'],
-      ['y.qq.com.*song/(\\w+).html', 'tencent', 'song'],
-      ['y.qq.com.*album/(\\w+).html', 'tencent', 'album'],
-      ['y.qq.com.*singer/(\\w+).html', 'tencent', 'artist'],
-      ['y.qq.com.*playsquare/(\\w+).html', 'tencent', 'playlist'],
-      ['y.qq.com.*playlist/(\\w+).html', 'tencent', 'playlist'],
+      ['y.qq.com.*song/(\\w+)(\\.html)?', 'tencent', 'song'],
+      ['y.qq.com.*album/(\\w+)(\\.html)?', 'tencent', 'album'],
+      ['y.qq.com.*singer/(\\w+)(\\.html)?', 'tencent', 'artist'],
+      ['y.qq.com.*playsquare/(\\w+)(\\.html)?', 'tencent', 'playlist'],
+      ['y.qq.com.*playlist/(\\w+)(\\.html)?', 'tencent', 'playlist'],
       ['xiami.com.*song/(\\w+)', 'xiami', 'song'],
       ['xiami.com.*album/(\\w+)', 'xiami', 'album'],
       ['xiami.com.*artist/(\\w+)', 'xiami', 'artist'],
@@ -138,6 +142,8 @@ class MetingJSElement extends HTMLElement {
     this.appendChild(div)
 
     this.aplayer = new APlayer(options)
+    const customEvent = new CustomEvent('load', { detail: this })
+    this.dispatchEvent(customEvent)
   }
 
 }


### PR DESCRIPTION
**First:** 首先非常感谢作者延续维护了`meting-js`，感谢你的工作！Thanks♪(･ω･)ﾉ

**And then:** 现在 QQ 音乐歌单页面链接默认是不带 `.html`的，所以希望能够把 `.html`的正则解析变为可选的，另外也希望`meting-js`自定义元素内部能够新增两个自定义事件，因为目前只有`aplayer`实例本身能够触发一些事件，如果在`meting-js`这一层出现错误的话，就走不到`aplayer`实例化那一步，所以前端这边也无法很好的感知到发生了什么事，所以希望通过在`meting-js`这层增加两个钩子以方便前端做出相应的处理，在组件化应用场景中大有裨益。

- **通过外界 DIY 时：**
  - `parse-error`事件可以用于监测歌单链接是否有效。
  -  `load`事件可以在 `meting-js`和 `APlayer`准备就绪后，方便获取相关实例并进行安全的操作。
<img width="1451" alt="image" src="https://github.com/xizeyoupan/MetingJS/assets/39730999/cd907166-a2ae-400b-a033-d0b6b6af0420">

- **不带 .html 的歌单页：**
<img width="1185" alt="image" src="https://github.com/xizeyoupan/MetingJS/assets/39730999/be626942-7600-4457-bbb6-3e9172df7b15">
